### PR TITLE
Add config 'security-group-id'

### DIFF
--- a/spotr/config.py
+++ b/spotr/config.py
@@ -8,6 +8,7 @@ from botocore.configloader import raw_config_parse
 class Config:
     def __init__(self, client, args, config_file_path = "~/.spotr/config"):
         self.client = client
+        config_file_path = os.path.expanduser(config_file_path)
         if os.path.isfile(config_file_path):
             self._config = raw_config_parse(config_file_path)['config']
         else:
@@ -47,6 +48,9 @@ class Config:
     def az(self):
         return self._config['az']
 
+    @property
+    def security_group_id(self):
+        return self._config.get('security_group_id')
 
     def _get_required(self, key):
         if not self._config.get(key):

--- a/spotr/spot_instance.py
+++ b/spotr/spot_instance.py
@@ -24,6 +24,10 @@ def request(client, config, tag, get_by_instance_id, open_port):
 
 def _perform_request(client, config):
     random_id = str(random.random() * 1000)
+    if config.security_group_id is None:
+        security_group_ids = []
+    else:
+        security_group_ids = [config.security_group_id]
     response = client.request_spot_instances(
         SpotPrice=config.max_bid,
         ClientToken=random_id,
@@ -35,7 +39,8 @@ def _perform_request(client, config):
             'InstanceType': config.type,
             'Placement': {
                 'AvailabilityZone': config.az,
-            }
+            },
+            'SecurityGroupIds': security_group_ids
         }
     )
     return response.get('SpotInstanceRequests')[0].get('SpotInstanceRequestId')

--- a/spotr/spotr.py
+++ b/spotr/spotr.py
@@ -36,6 +36,9 @@ launch_parser.add_argument(
 launch_parser.add_argument(
     '--key-name',
     help='name of the aws key pair to use')
+launch_parser.add_argument(
+    '--security-group-id',
+    help='security group id for the security group to use')
 launch_parser.set_defaults(func=launch)
 
 destroy_parser = subparsers.add_parser('snapshot')


### PR DESCRIPTION
This config can be used to use create a spot instance with a specific security group. It enables the user to  use a security group with any inboud/outbound rules.

My specific issue was that the SSH port is not opened by default (which should also be fixed). Having a config like this (in addition to the default behavior) is more flexible though and seems to be a desired feature by not only me (see issue #16).