### PR TITLE
Adding support for passing subnet-id in the configuration while launc…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/*
 *.pyc
 .tox
 .cache
+.idea

--- a/spotr/config.py
+++ b/spotr/config.py
@@ -52,6 +52,10 @@ class Config:
     def security_group_id(self):
         return self._config.get('security_group_id')
 
+    @property
+    def subnet_id(self):
+        return self._config.get('subnet_id')
+
     def _get_required(self, key):
         if not self._config.get(key):
             raise RuntimeError("Missing required parameter: {0}".format(key))

--- a/spotr/spot_instance.py
+++ b/spotr/spot_instance.py
@@ -27,7 +27,7 @@ def _perform_request(client, config):
     if config.security_group_id is None:
         security_group_ids = []
     else:
-	    security_group_ids = [config.security_group_id]
+	security_group_ids = [config.security_group_id]
     response = client.request_spot_instances(
         SpotPrice=config.max_bid,
         ClientToken=random_id,
@@ -41,7 +41,7 @@ def _perform_request(client, config):
                 'AvailabilityZone': config.az,
             },
             'SecurityGroupIds': security_group_ids,
-	        'SubnetId':config.subnet_id
+	    'SubnetId':config.subnet_id
         }
     )
     return response.get('SpotInstanceRequests')[0].get('SpotInstanceRequestId')

--- a/spotr/spot_instance.py
+++ b/spotr/spot_instance.py
@@ -27,7 +27,7 @@ def _perform_request(client, config):
     if config.security_group_id is None:
         security_group_ids = []
     else:
-        security_group_ids = [config.security_group_id]
+	    security_group_ids = [config.security_group_id]
     response = client.request_spot_instances(
         SpotPrice=config.max_bid,
         ClientToken=random_id,
@@ -40,7 +40,8 @@ def _perform_request(client, config):
             'Placement': {
                 'AvailabilityZone': config.az,
             },
-            'SecurityGroupIds': security_group_ids
+            'SecurityGroupIds': security_group_ids,
+	        'SubnetId':config.subnet_id
         }
     )
     return response.get('SpotInstanceRequests')[0].get('SpotInstanceRequestId')

--- a/spotr/spotr.py
+++ b/spotr/spotr.py
@@ -39,6 +39,9 @@ launch_parser.add_argument(
 launch_parser.add_argument(
     '--security-group-id',
     help='security group id for the security group to use')
+launch_parser.add_argument(
+    '--subnet-id',
+    help='id of the subnet in which instance needs to be launched')
 launch_parser.set_defaults(func=launch)
 
 destroy_parser = subparsers.add_parser('snapshot')


### PR DESCRIPTION
p2.xlarge instances cannot be launched without specifying a VPC. Adding support to pass subnet-id params during the launch.